### PR TITLE
fix: use "ViewProps.style" for the `style` type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@ interface PickerProps {
   itemStyle?: ReactNative.TextProps;
   onValueChange: (val: any) => void;
   pickerData: any[];
-  style: ReactNative.ViewProps;
+  style: ReactNative.ViewProps['style'];
   selectedValue: any;
 }
 
@@ -29,7 +29,7 @@ interface DatePickerAndroidProps {
   };
   order?: string;
   use12Hours?: boolean;
-  style?: ReactNative.ViewProps;
+  style?: ReactNative.ViewProps['style'];
   textColor?: string;
   textSize?: number;
   itemSpace?: number;


### PR DESCRIPTION
Fixes error in typescript definitions. Needed to dig into ViewProps a bit.